### PR TITLE
Convert requested volume size to number of bytes

### DIFF
--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -2,6 +2,7 @@ package provisioner
 
 import (
 	"fmt"
+	"strconv"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
@@ -59,8 +60,9 @@ func (p ZFSProvisioner) createVolume(options controller.VolumeOptions) (string, 
 	properties["sharenfs"] = fmt.Sprintf("rw=@%s%s", p.shareSubnet, p.shareOptions)
 
 	storageRequest := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	properties["refquota"] = storageRequest.String()
-	properties["refreservation"] = storageRequest.String()
+	storageRequestBytes := strconv.FormatInt(storageRequest.Value(), 10)
+	properties["refquota"] = storageRequestBytes
+	properties["refreservation"] = storageRequestBytes
 
 	dataset, err := zfs.CreateFilesystem(zfsPath, properties)
 	if err != nil {


### PR DESCRIPTION
Without this patch, volume creation on Ubuntu 16.04 was failing like this:

Creating ZFS dataset failed with: exit status 1: "/sbin/zfs zfs create -o
refquota=8Gi -o refreservation=8Gi -o sharenfs=rw=@1.2.3.0/29
tank/kube/pvc-1ae2f49c-53c1-11e8-8648-52540002f13f" => cannot create
'tank/kube/pvc-1ae2f49c-53c1-11e8-8648-52540002f13f': invalid numeric suffix
'Gi'

Fixes #4.